### PR TITLE
Atualização do Vite para >=6.2.6 devido a razões de segurança.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "autoprefixer": "^10.4.21",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0",
+    "vite": ">=6.2.6",
     "vue-tsc": "^2.2.4"
   }
 }


### PR DESCRIPTION
Correção de vulnerabilidade.
Requer correr `npm install` para atualizar o pacote.

Farto de ler o Dependabot a queixar-se do Vite. O meu email está a ficar cheio com avisos de segurança.
![image](https://github.com/user-attachments/assets/e0cc1fef-726a-4102-b274-bad44427fbf8)

